### PR TITLE
Added ComputerConfigs

### DIFF
--- a/ComputerConfigs/158/158.cfg
+++ b/ComputerConfigs/158/158.cfg
@@ -1,0 +1,8 @@
+-- can also have the path to a setup file, that is used for more than 1 computer/turtle
+
+-- NEEDS:
+-- startup 
+-- boot.sys
+-- api`s
+-- programs
+-- "static" data like FTB_Lite1_ItemDump

--- a/ComputerConfigs/global.cfg
+++ b/ComputerConfigs/global.cfg
@@ -1,0 +1,2 @@
+-- can hold paths to scripts that turn out to be commonly used scripts
+-- ex: apiManager, it´s boot.sys (maybe have dynamic boot.sys? formed by setup config?)


### PR DESCRIPTION
- Computer config files should contain the pointers to relevant scripts
- gitAPI could look for a computer´s id and find the reffered cfg file
- then only downloads the scripts that have been designated in the cfg
- Not yet clear how the implementation should look...